### PR TITLE
Update s3sync.yml to use self-hosted runner

### DIFF
--- a/.github/workflows/s3sync.yml
+++ b/.github/workflows/s3sync.yml
@@ -12,24 +12,20 @@ env:
 jobs:
   sync:
     name: Sync simpleitk bucket
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install awscli
-    - name: Configure AWS credentials
+    - name: Configure AWS credentials from Test account
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.region }}
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-        role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-        role-duration-seconds: 1200
-        role-session-name: svc-simpleitk
-        role-skip-session-tagging: true
+        role-to-assume: arn:aws:iam::774096297494:role/cicd-runner-admin
+        aws-region: us-east-1
+        # role-skip-session-tagging: true
+        role-duration-seconds: 3600
     - name: Push MD5 and SHA512 to S3 simpleitk
       run: |
         aws s3 sync . s3://${{ env.bucket }}/public --exclude "*" --include "MD5/*" --include "SHA512/*" --size-only


### PR DESCRIPTION
This workflow still uses the old role that was attached through the old simpleitk account.  This PR updates the workflow to use the Monarch self-hosted runner instead.